### PR TITLE
Support custom localisation and other yadda options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ Running `ember serve` will make the test results available at `http://localhost:
     * Un-install the latest version of yadda from npm: `npm uninstall yadda --save-dev`.
     * Install the desired version of yadda: `npm install yadda@<desired version> --save-dev`.
 
+## Configuration
+You can set custom yadda configuration. It should be set in your project's config/environment.js file into `ENV.APP.yadda` property. For example, to get support for French gherkin syntax, you should have:
+```js
+// ...
+if (environment === 'test') {
+  // ...
+  ENV.APP.yadda = {
+    language: 'French'
+  };
+}
+// ...
+```
+
+##### Config options
+* `language` - (default: "English") The full list of supported languages is available on [yadda repository](https://github.com/acuminous/yadda/tree/master/lib/localisation)
+*note: keep in mind that case sensitivity is important for language settings*
+* `leftPlaceholderChar` - (default: "[")
+* `rightPlaceholderChar` - (default: "]")
+*note: placeholder characters are use for example in Scenario Outlines*
 
 ## Usage
 This ember-cli addon provides you with two blueprints with which you can create feature files.
@@ -72,19 +91,19 @@ This will generate the following files in your project directory:
 /tests/acceptance/make-a-feature.feature
 ```
 
-When using Mocha as your test framework, you have the option to run each scenario's step as a separate test, with all steps grouped within a Mocha `describe` block. If a step is failing, all following steps of that scenario will then be marked as pending. This way you get a much clearer picture on where (which step) a possible failure is happening. To opt in into that mode, use the `separateSteps` config option. 
- 
+When using Mocha as your test framework, you have the option to run each scenario's step as a separate test, with all steps grouped within a Mocha `describe` block. If a step is failing, all following steps of that scenario will then be marked as pending. This way you get a much clearer picture on where (which step) a possible failure is happening. To opt in into that mode, use the `separateSteps` config option.
+
  ```js
  // ember-cli-build.js
- 
+
      var app = new EmberApp({
          'ember-cli-yadda': {
              'separateSteps': true
          }
      });
- 
+
  ```
- 
+
  *Note that this mode is currently not available when you are using QUnit as your test framework!*
 
 ##### Unit tests
@@ -163,7 +182,7 @@ export default function(assert) {
 
 For example, creating a feature file for a component named `form-select`, you would use `ember g feature-unit components/form-select`
 
-You can skip tests by adding the `@ignore` annotation above the Scenario or Feature. 
+You can skip tests by adding the `@ignore` annotation above the Scenario or Feature.
 
 ## Important information
 ##### Scope and helpers

--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ if (environment === 'test') {
 ```
 
 ##### Config options
-* `language` - (default: "English") The full list of supported languages is available on [yadda repository](https://github.com/acuminous/yadda/tree/master/lib/localisation)
-*note: keep in mind that case sensitivity is important for language settings*
-* `leftPlaceholderChar` - (default: "[")
-* `rightPlaceholderChar` - (default: "]")
-*note: placeholder characters are use for example in Scenario Outlines*
+* `language` - (default: "English") The full list of supported languages is available on [yadda repository](https://github.com/acuminous/yadda/tree/master/lib/localisation) *note: keep in mind that case sensitivity is important for language settings*
+* `leftPlaceholderChar` - (default: "[") *used for example in Scenario Outlines*
+* `rightPlaceholderChar` - (default: "]") *used for example in Scenario Outlines*
 
 ## Usage
 This ember-cli addon provides you with two blueprints with which you can create feature files.

--- a/config/environment.js
+++ b/config/environment.js
@@ -4,6 +4,9 @@
 module.exports = function(/* environment, appConfig */) {
   return {
     //merged with the consuming application's ENV
+    yadda: {
+      language: 'English'
+    },
     browserify: {
       tests: true
     }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,10 @@ module.exports = {
     var env = 'test';
     var yaddaConfig = this.config(env).yadda || {};
     var appYaddaConfig = this.project.config(env).APP.yadda || {};
-    yaddaConfig = Object.assign(yaddaConfig, appYaddaConfig);
+    for(var key in appYaddaConfig) {
+      if(!appYaddaConfig.hasOwnProperty(key)) continue;
+      yaddaConfig[key] = appYaddaConfig[key];
+    }
 
     registry.add('js', {
       name: 'ember-cli-yadda',

--- a/index.js
+++ b/index.js
@@ -17,11 +17,16 @@ module.exports = {
   setupPreprocessorRegistry: function(type, registry) {
     var testFramework = this.getTestFramework();
     var self = this;
+    var env = 'test';
+    var yaddaConfig = this.config(env).yadda || {};
+    var appYaddaConfig = this.project.config(env).APP.yadda || {};
+    yaddaConfig = Object.assign(yaddaConfig, appYaddaConfig);
+
     registry.add('js', {
       name: 'ember-cli-yadda',
       ext: ['feature', 'spec', 'specification'],
       toTree: function(tree, inputPath, outputPath) {
-        return new FeatureParser(tree, testFramework, self.options);
+        return new FeatureParser(tree, testFramework, self.options, yaddaConfig);
       }
     });
   },

--- a/lib/feature-parser.js
+++ b/lib/feature-parser.js
@@ -11,10 +11,15 @@ var inflected = require('inflected');
 FeatureParser.prototype = Object.create(Filter.prototype);
 
 FeatureParser.prototype.constructor = FeatureParser;
-function FeatureParser(inputNode, testFramework, options) {
+function FeatureParser(inputNode, testFramework, options, yaddaConfig) {
+  yaddaConfig = yaddaConfig || {};
+  if(typeof yaddaConfig.language === "string") {
+    yaddaConfig.language = yadda.localisation[yaddaConfig.language];
+  }
   this.testFramework = testFramework;
   this.testRunnerCache = {};
   this.options = options;
+  this.yaddaConfig = yaddaConfig;
   Filter.call(this, inputNode);
 }
 
@@ -23,7 +28,7 @@ FeatureParser.prototype.extensions = ['feature', 'spec', 'specification'];
 FeatureParser.prototype.targetExtension = 'js';
 
 FeatureParser.prototype.processString = function(content, relativePath) {
-  var feature = new yadda.parsers.FeatureParser().parse(content);
+  var feature = new yadda.parsers.FeatureParser(this.yaddaConfig).parse(content);
   var basePath = relativePath.split('/').slice(0,2).join('/');
   var nestedPath = relativePath.split('/').length > 4 ? relativePath.split('/').slice(3,-1).join('/') + '/' : '';
   var fileName = relativePath.split('/').slice(-1)[0].split('.')[0]; //remove extension


### PR DESCRIPTION
At my work we're using fork of ember-cli-yadda everyday in cooperation with architects. There are already only 2 missing functionalities in this plugin which we need to use original plugin (BTW thanks for adding @Ignore annotation, that is what we've also needed). I mean:
* Support custom localisation (Our achitects are writing tests in our native language)
* Support another yadda options

Our fork of ember-cli-yadda has hardcoded FeatureParser initialization, it looks like that:
```js
var feature = new yadda.parsers.FeatureParser({
  language: yadda.localisation.Polish,
  leftPlaceholderChar: '<',
  rightPlaceholderChar: '>'
}).parse(content);
```
We need also possibility to change square brackets into angle brackets for using variables due to cooperation also with PHP Team. They are using Behat, and there are angle brackets for using variables [behat docs](http://behat.org/en/latest/user_guide/writing_scenarios.html#scenario-outlines). We've decided to be consistent with PHP Team.

With this PR changes we will be able to set custom yadda config in our app environment config by adding:
```js
ENV.APP.yadda = {
  language: 'Polish',
  leftPlaceholderChar: '<',
  rightPlaceholderChar: '>'
};
```

So here is my PR which should resolve our problems and allows us to use official version of ember-cli-yadda. I'm open to any suggestions if it needs some improvements.

I wanted to write some tests, but it needs some tricky way to use custom acceptance tests directory. Because with custom configuration current tests will definetly fail (and thats correct, using another localisation, english tests can't work). I can add tests later in another PR (it really needs tricky way which i didn't want to include in this PR).

Note: this version of code is fully backward compatible.