### PR TITLE
Properly reject RSVP promises, fixes #62

### DIFF
--- a/lib/test-runner/mocha/acceptance.js
+++ b/lib/test-runner/mocha/acceptance.js
@@ -22,13 +22,9 @@ function testFeature(feature) {
 
           it(`Scenario: ${scenario.title}`, function() {
             let self = this;
-            return new Ember.RSVP.Promise(function(resolve) {
+            return new Ember.RSVP.Promise(function(resolve, reject) {
               yadda.Yadda(library.default(), self).yadda(scenario.steps, { ctx: {} }, function next(err, result) {
-                if (err) {
-                  throw err;
-                }
-
-                resolve(result);
+                err ? reject(err) : resolve(result);
               });
             });
           });

--- a/lib/test-runner/mocha/separate/acceptance.js
+++ b/lib/test-runner/mocha/separate/acceptance.js
@@ -25,14 +25,14 @@ function testFeature(feature) {
                   this.skip();
                 } else {
                   let self = this;
-                  let promise = new Ember.RSVP.Promise(function(resolve) {
+                  let promise = new Ember.RSVP.Promise(function(resolve, reject) {
                     yadda.Yadda(library.default(), self).yadda(step, context, function next(err, result) {
                       if (err) {
                         failed = true;
-                        throw err;
+                        reject(err);
+                      } else {
+                        resolve(result);
                       }
-
-                      resolve(result);
                     });
                   });
 

--- a/lib/test-runner/qunit/acceptance.js
+++ b/lib/test-runner/qunit/acceptance.js
@@ -23,12 +23,9 @@ function testFeature(feature) {
 
         test(`Scenario: ${scenario.title}`, function(assert) {
           let self = this;
-          return new Ember.RSVP.Promise(function(resolve) {
+          return new Ember.RSVP.Promise(function(resolve, reject) {
             yadda.Yadda(library.default(assert), self).yadda(scenario.steps, { ctx: {} }, function next(err, result) {
-              if (err) {
-                throw err;
-              }
-              resolve(result);
+              err ? reject(err) : resolve(result);
             });
           });
         });

--- a/lib/test-runner/qunit/component.js
+++ b/lib/test-runner/qunit/component.js
@@ -7,13 +7,9 @@ function testFeature(feature) {
   feature.scenarios.forEach(function(scenario) {
     test(`Scenario: ${scenario.title}`, function(assert) {
       let self = this;
-      return new Ember.RSVP.Promise(function(resolve) {
+      return new Ember.RSVP.Promise(function(resolve, reject) {
         yadda.Yadda(library.default(assert), self).yadda(scenario.steps, { ctx: {} }, function next(err, result) {
-          if (err) {
-            throw err;
-          }
-
-          resolve(result);
+          err ? reject(err) : resolve(result);
         });
       });
     });


### PR DESCRIPTION
Looks like a bug in RSVP, if you ask me. A vanilla promise wouldn't require this change.

I didn't find any test infrastructure in the addon to test the tests (`xzibit_meme.jpg`), so I'm not providing a test with this PR.