### PR TITLE
Don't override this.options

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
       name: 'ember-cli-yadda',
       ext: ['feature', 'spec', 'specification'],
       toTree(tree) {
-        return new FeatureParser(tree, testFramework, self.options);
+        return new FeatureParser(tree, testFramework, self._options);
       }
     });
   },
@@ -33,6 +33,6 @@ module.exports = {
     if (typeof options.persist === 'undefined') {
       options.persist = true;
     }
-    this.options = options;
+    this._options = options;
   }
 };


### PR DESCRIPTION
`this.options` is already used by the parent class. Overriding caused this error for ember-cli-babel 6:
```
DEPRECATION: Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. `ember-cli-yadda` (found at `/Users/simonihmig/Projects/ember-cli-yadda`) has overridden the `this.options.babel` options which conflicts with the addons ability to transpile its `addon/` files properly. Falling back to default babel configuration options.
```