### PR TITLE
Set Yadda options

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ import yadda from '../../helpers/yadda';
 import { visit } from '@ember/test-helpers';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given("I have bananas", async function() {
       await visit("/bananas");
     });

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ your Ember test setup using either [ember-qunit](https://github.com/emberjs/embe
 [ember-mocha](https://github.com/emberjs/ember-mocha).
 
 The following describes the use of ember-cli-yadda >= v0.4.0 which works only with the latest modern
-Ember testing APIs, as laid out in the RFCs 
-[232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md) 
-and 
+Ember testing APIs, as laid out in the RFCs
+[232](https://github.com/emberjs/rfcs/blob/master/text/0232-simplify-qunit-testing-api.md)
+and
 [268](https://github.com/emberjs/rfcs/blob/master/text/0268-acceptance-testing-refactor.md).
 
 For the older APIs use v0.3.x and have a look at our [Legacy Guide](docs/legacy.md).
@@ -40,7 +40,7 @@ You may specify the version of yadda by changing it in package.json and running 
 
 ## Upgrading
 
-To upgrade to the latest version of this addon from a previous release < 0.4.0, including refactoring your existing 
+To upgrade to the latest version of this addon from a previous release < 0.4.0, including refactoring your existing
 tests to Ember's new testing APIs, follow these steps:
 
 - Install the latest version of ember-cli-yadda.
@@ -49,11 +49,11 @@ tests to Ember's new testing APIs, follow these steps:
 - Refactor your step files to use the new testing APIs:
   - for application tests, skip using Ember's global test helpers and use those provided by [@ember/test-helpers](https://github.com/emberjs/ember-test-helpers).
   - use `async`/`await` for all asynchronous operations, including `andThen()`
-  - [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) will be able to do most of 
+  - [ember-test-helpers-codemod](https://github.com/simonihmig/ember-test-helpers-codemod) will be able to do most of
     these changes automatically
   - For further details have a look at the [Migration Guide for QUnit](https://github.com/emberjs/ember-qunit/blob/master/docs/migration.md)
     or the [Migration Guide for Mocha](https://github.com/emberjs/ember-mocha/blob/master/docs/migration.md#upgrading-to-the-new-testing-apis)
-- *Optional*: customize `tests/helpers/yadda-annotations.js` with any additional setup logic that is needed, see 
+- *Optional*: customize `tests/helpers/yadda-annotations.js` with any additional setup logic that is needed, see
   [here](#customization)
 
 ## Usage
@@ -89,8 +89,8 @@ This will generate the following files in your project directory:
 
 #### Integration or unit tests
 
-To create an integration or unit test, you can use `ember g feature [feature title] --type=integration` for an 
-integration test, or `--type=unit` for a unit test. This generates a feature and step definition file where you can 
+To create an integration or unit test, you can use `ember g feature [feature title] --type=integration` for an
+integration test, or `--type=unit` for a unit test. This generates a feature and step definition file where you can
 write your tests.
 
 For example:
@@ -121,16 +121,16 @@ Feature: bananas rot
     Then the banana rots
 ```
 
-The `@setupApplicationTest` annotation will setup all scenarios of this feature as application tests, using the 
+The `@setupApplicationTest` annotation will setup all scenarios of this feature as application tests, using the
 `setupApplicationTest()` function provided by either `ember-qunit` or `ember-mocha`. See the [Annotations](#annotations)
 section below for more information on how to setup your tests.
 
-Because we probably have more features about bananas, we add the `Given I have bananas` to the global steps file: 
+Because we probably have more features about bananas, we add the `Given I have bananas` to the global steps file:
 `/tests/acceptance/steps.js`
 
 ```js
 import yadda from '../../helpers/yadda';
-import { visit } from '@ember/test-helpers'; 
+import { visit } from '@ember/test-helpers';
 
 export default function(assert) {
   return yadda.localisation.English.library()
@@ -140,7 +140,7 @@ export default function(assert) {
 }
 ```
 
-*Notice that the preferable way to handle asynchronous steps like the one above is to use `async`/ `await`. But you can 
+*Notice that the preferable way to handle asynchronous steps like the one above is to use `async`/ `await`. But you can
 also explicitly return a promise or use a `next()` [callback](https://acuminous.gitbooks.io/yadda-user-guide/en/usage/step-libraries.html).*
 
 The fact that "it's next to apples" is probably unique to this Feature so we'll add it to the feature specific step definitions in `/tests/acceptance/steps/bananas-rot-feature-steps.js`. That will look like this:
@@ -172,8 +172,8 @@ export default function(assert) {
 
 ##### Scope and helpers
 
-ember-cli-yadda passes the original scope down to each step definition. This means that you have access to the same 
-context (like `this.element` or `this.owner`) and helpers from `@ember/test-helpers` (like `click()`), as you did when 
+ember-cli-yadda passes the original scope down to each step definition. This means that you have access to the same
+context (like `this.element` or `this.owner`) and helpers from `@ember/test-helpers` (like `click()`), as you did when
 writing a normal test in QUnit/Mocha.
 
 ##### Sharing variables between steps
@@ -215,23 +215,23 @@ You already saw the use of the `@setupApplicationTest` annotation in the example
 Yadda's [support for annotations](https://acuminous.gitbooks.io/yadda-user-guide/en/feature-specs/annotations.html`) can
 be used to customize the way tests are run.
 
-The implementation for the way certain annotations affect your tests lives in the `tests/yadda-annotations.js` file. 
+The implementation for the way certain annotations affect your tests lives in the `tests/yadda-annotations.js` file.
 The addon installs this file with a default implementation as described below, but you can freely customize it at your
 will.
 
 #### Skipping tests
 
-You can skip tests by adding the `@ignore` annotation above the Scenario or Feature. 
+You can skip tests by adding the `@ignore` annotation above the Scenario or Feature.
 
 #### Test suites
 
-You can set `ENV.annotations` to an array of annotations (either statically or e.g. by assigning them from an 
+You can set `ENV.annotations` to an array of annotations (either statically or e.g. by assigning them from an
 environment variable like `process.env.ANNOTATIONS`). This will then run only those Features or Scenarios that have one
 of these annotations assigned.
 
 #### Setup tests
 
-For each of the setup functions already known from `ember-qunit` or `ember-mocha`, there exists a corresponding 
+For each of the setup functions already known from `ember-qunit` or `ember-mocha`, there exists a corresponding
 annotation to setup your Feature/Scenario accordingly:
 
 - `@setupTest` for (unit) tests requiring the DI container of Ember to be set up
@@ -240,20 +240,20 @@ annotation to setup your Feature/Scenario accordingly:
 
 #### Customization
 
-You can customize how annotations are handled in your app's `tests/yadda-annotations.js` file, e.g. to add support for 
+You can customize how annotations are handled in your app's `tests/yadda-annotations.js` file, e.g. to add support for
 additional annotations, or extend the existing ones. This module has to export these hooks, that are called by this
 addon's test runner:
 
 - `runFeature`: called for each feature. If you return a function, this will be called to run the feature, instead of
   the default implementation.
 - `runScenario`: similar to `runFeature`, but called for each scenario.
-- `setupFeature`: called for each feature to setup the test environment. You can call QUnit's or Mocha's `beforeEach` 
+- `setupFeature`: called for each feature to setup the test environment. You can call QUnit's or Mocha's `beforeEach`
   and `afterEach` functions here to add custom setup/teardown work.
 - `setupScenario`: similar to `setupFeature`, but called for each scenario.
 
 Have a look at the existing implementation and the comments present in your `tests/yadda-annotations.js` file!
 
-Here is an example to extend the defaul implementation of the `@setupApplicationTest` annotation to also call the 
+Here is an example to extend the defaul implementation of the `@setupApplicationTest` annotation to also call the
 `setupMirage()` function provided by `ember-cli-mirage` to setup the Mirage server:
 
 ```js
@@ -271,6 +271,25 @@ function setupYaddaTest(annotations) {
   // ...
 }
 ```
+
+### Yadda Configuration
+If you need to set Yadda configuration, add the following to `ember-cli-build.js`:
+
+```javascript
+module.exports = function(defaults) {
+  let app = new EmberApp(defaults, {
+
+    'ember-cli-yadda': {
+      yaddaOptions: { // passed through to yadda parseFeature()
+        language: 'Polish', // converted to Yadda.localisation.Polish
+        leftPlaceholderChar: '<',
+        rightPlaceholderChar: '>'
+      }
+
+    }
+  });
+```
+See [yadda FeatureParser]([https://github.com/acuminous/yadda/blob/master/lib/parsers/FeatureParser.js#L8]) for yadda options.
 
 ## Inner workings
 

--- a/blueprints/mocha/ember-cli-yadda/files/tests/acceptance/steps/steps.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/acceptance/steps/steps.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { visit } from '@ember/test-helpers';
 
 export default function() {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', async function() {
       await visit('/');
       expect(true, this.step).to.be.true;

--- a/blueprints/mocha/ember-cli-yadda/files/tests/helpers/yadda-annotations.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/helpers/yadda-annotations.js
@@ -53,8 +53,8 @@ function setupFeature(featureAnnotations) {
 
 function setupScenario(featureAnnotations, scenarioAnnotations) {
   let setupFn = setupYaddaTest(scenarioAnnotations);
-  if (setupFn && (featureAnnotations.application || featureAnnotations.rendering || featureAnnotations.context)) {
-    throw new Error('You must not assign any @application, @rendering or @context annotations to a scenario as well as its feature!');
+  if (setupFn && (featureAnnotations.setupapplicationtest || featureAnnotations.setuprenderingtest || featureAnnotations.setuptest)) {
+    throw new Error('You must not assign any @setupapplicationtest, @setuprenderingtest or @setuptest annotations to a scenario as well as its feature!');
   }
   return setupFn;
 }

--- a/blueprints/mocha/ember-cli-yadda/files/tests/integration/steps/steps.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/integration/steps/steps.js
@@ -2,7 +2,7 @@ import yadda from '../../helpers/yadda';
 import { expect } from 'chai';
 
 export default function() {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       expect(true, this.step).to.be.true;
     })

--- a/blueprints/mocha/ember-cli-yadda/files/tests/unit/steps/steps.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/unit/steps/steps.js
@@ -2,7 +2,7 @@ import yadda from '../../helpers/yadda';
 import { expect } from 'chai';
 
 export default function() {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       expect(true, this.step).to.be.true;
     })

--- a/blueprints/qunit/ember-cli-yadda/files/tests/acceptance/steps/steps.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/acceptance/steps/steps.js
@@ -2,7 +2,7 @@ import yadda from '../../helpers/yadda';
 import { visit } from '@ember/test-helpers';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', async function() {
       await visit('/');
       assert.ok(true, this.step);

--- a/blueprints/qunit/ember-cli-yadda/files/tests/helpers/yadda-annotations.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/helpers/yadda-annotations.js
@@ -53,8 +53,8 @@ function setupFeature(featureAnnotations) {
 
 function setupScenario(featureAnnotations, scenarioAnnotations) {
   let setupFn = setupYaddaTest(scenarioAnnotations);
-  if (setupFn && (featureAnnotations.application || featureAnnotations.rendering || featureAnnotations.context)) {
-    throw new Error('You must not assign any @application, @rendering or @context annotations to a scenario as well as its feature!');
+  if (setupFn && (featureAnnotations.setupapplicationtest || featureAnnotations.setuprenderingtest || featureAnnotations.setuptest)) {
+    throw new Error('You must not assign any @setupapplicationtest, @setuprenderingtest or @setuptest annotations to a scenario as well as its feature!');
   }
   return setupFn;
 }

--- a/blueprints/qunit/ember-cli-yadda/files/tests/integration/steps/steps.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/integration/steps/steps.js
@@ -1,7 +1,7 @@
 import yadda from '../../helpers/yadda';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       assert.ok(true, this.step);
     })

--- a/blueprints/qunit/ember-cli-yadda/files/tests/unit/steps/steps.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/unit/steps/steps.js
@@ -1,7 +1,7 @@
 import yadda from '../../helpers/yadda';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       assert.ok(true, this.step);
     })

--- a/lib/feature-parser.js
+++ b/lib/feature-parser.js
@@ -12,10 +12,16 @@ class FeatureParser extends Filter {
     this.options = options;
     this.extensions = ['feature', 'spec', 'specification'];
     this.targetExtension = 'js';
+
+    let yaddaOptions = options.yaddaOptions || {};
+    if (typeof yaddaOptions.language === 'string') {
+      yaddaOptions.language = yadda.localisation[yaddaOptions.language];
+    }
+    this.yaddaOptions = yaddaOptions;
   }
 
   processString(content, relativePath) {
-    let feature = new yadda.parsers.FeatureParser().parse(content);
+    let feature = new yadda.parsers.FeatureParser(this.yaddaOptions).parse(content);
     let pathParts = relativePath.split('/');
     let basePath = pathParts.slice(0, 2).join('/');
     let fileName = pathParts.slice(-1)[0].split('.')[0]; //remove extension
@@ -29,9 +35,9 @@ class FeatureParser extends Filter {
       import * as library from '${stepsPath}/${fileName}-steps';
       import yaddaAnnotations from '${basePath}/helpers/yadda-annotations';
       import testRunner from 'ember-cli-yadda/test-support/${this.testFramework}/test-runner';
-      
+
       const feature = ${JSON.stringify(feature, null, 2)};
-      
+
       testRunner(feature, yadda, yaddaAnnotations, library);
     `;
 

--- a/lib/feature-parser.js
+++ b/lib/feature-parser.js
@@ -13,14 +13,19 @@ class FeatureParser extends Filter {
     this.extensions = ['feature', 'spec', 'specification'];
     this.targetExtension = 'js';
 
-    let yaddaOptions = options.yaddaOptions || {};
-    if (typeof yaddaOptions.language === 'string') {
-      yaddaOptions.language = yadda.localisation[yaddaOptions.language];
+    //pull language from original options, if it exists
+    this.yaddaLanguage = 'English';
+    if (options.yaddaOptions && options.yaddaOptions.language) {
+      this.yaddaLanguage = options.yaddaOptions.language;
     }
-    this.yaddaOptions = yaddaOptions;
+
+    //clone options and change change language to be the object
+    this.yaddaOptions = Object.assign({}, options.yaddaOptions);
+    this.yaddaOptions.language = yadda.localisation[this.yaddaLanguage];
   }
 
   processString(content, relativePath) {
+
     let feature = new yadda.parsers.FeatureParser(this.yaddaOptions).parse(content);
     let pathParts = relativePath.split('/');
     let basePath = pathParts.slice(0, 2).join('/');
@@ -37,6 +42,8 @@ class FeatureParser extends Filter {
       import testRunner from 'ember-cli-yadda/test-support/${this.testFramework}/test-runner';
 
       const feature = ${JSON.stringify(feature, null, 2)};
+
+      yadda.localisation.default = yadda.localisation.${this.yaddaLanguage};
 
       testRunner(feature, yadda, yaddaAnnotations, library);
     `;

--- a/node-tests/fixtures/main/mocha/acceptance/steps/steps.js
+++ b/node-tests/fixtures/main/mocha/acceptance/steps/steps.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { visit } from '@ember/test-helpers';
 
 export default function() {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', async function() {
       await visit('/');
       expect(true, this.step).to.be.true;

--- a/node-tests/fixtures/main/mocha/helpers/yadda-annotations.js
+++ b/node-tests/fixtures/main/mocha/helpers/yadda-annotations.js
@@ -53,8 +53,8 @@ function setupFeature(featureAnnotations) {
 
 function setupScenario(featureAnnotations, scenarioAnnotations) {
   let setupFn = setupYaddaTest(scenarioAnnotations);
-  if (setupFn && (featureAnnotations.application || featureAnnotations.rendering || featureAnnotations.context)) {
-    throw new Error('You must not assign any @application, @rendering or @context annotations to a scenario as well as its feature!');
+  if (setupFn && (featureAnnotations.setupapplicationtest || featureAnnotations.setuprenderingtest || featureAnnotations.setuptest)) {
+    throw new Error('You must not assign any @setupapplicationtest, @setuprenderingtest or @setuptest annotations to a scenario as well as its feature!');
   }
   return setupFn;
 }

--- a/node-tests/fixtures/main/mocha/integration/steps/steps.js
+++ b/node-tests/fixtures/main/mocha/integration/steps/steps.js
@@ -2,7 +2,7 @@ import yadda from '../../helpers/yadda';
 import { expect } from 'chai';
 
 export default function() {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       expect(true, this.step).to.be.true;
     })

--- a/node-tests/fixtures/main/mocha/unit/steps/steps.js
+++ b/node-tests/fixtures/main/mocha/unit/steps/steps.js
@@ -2,7 +2,7 @@ import yadda from '../../helpers/yadda';
 import { expect } from 'chai';
 
 export default function() {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       expect(true, this.step).to.be.true;
     })

--- a/node-tests/fixtures/main/qunit/acceptance/steps/steps.js
+++ b/node-tests/fixtures/main/qunit/acceptance/steps/steps.js
@@ -2,7 +2,7 @@ import yadda from '../../helpers/yadda';
 import { visit } from '@ember/test-helpers';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', async function() {
       await visit('/');
       assert.ok(true, this.step);

--- a/node-tests/fixtures/main/qunit/helpers/yadda-annotations.js
+++ b/node-tests/fixtures/main/qunit/helpers/yadda-annotations.js
@@ -53,8 +53,8 @@ function setupFeature(featureAnnotations) {
 
 function setupScenario(featureAnnotations, scenarioAnnotations) {
   let setupFn = setupYaddaTest(scenarioAnnotations);
-  if (setupFn && (featureAnnotations.application || featureAnnotations.rendering || featureAnnotations.context)) {
-    throw new Error('You must not assign any @application, @rendering or @context annotations to a scenario as well as its feature!');
+  if (setupFn && (featureAnnotations.setupapplicationtest || featureAnnotations.setuprenderingtest || featureAnnotations.setuptest)) {
+    throw new Error('You must not assign any @setupapplicationtest, @setuprenderingtest or @setuptest annotations to a scenario as well as its feature!');
   }
   return setupFn;
 }

--- a/node-tests/fixtures/main/qunit/integration/steps/steps.js
+++ b/node-tests/fixtures/main/qunit/integration/steps/steps.js
@@ -1,7 +1,7 @@
 import yadda from '../../helpers/yadda';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       assert.ok(true, this.step);
     })

--- a/node-tests/fixtures/main/qunit/unit/steps/steps.js
+++ b/node-tests/fixtures/main/qunit/unit/steps/steps.js
@@ -1,7 +1,7 @@
 import yadda from '../../helpers/yadda';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .given('I type "Ember g feature make-feature"', function(){
       assert.ok(true, this.step);
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-yadda",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Ember-cli yadda addon for running Gherkin acceptance tests",
   "keywords": [
     "ember-addon",

--- a/tests/helpers/yadda.js
+++ b/tests/helpers/yadda.js
@@ -1,3 +1,2 @@
-// needed for dummy app to run
 import yadda from 'npm:yadda';
 export default yadda;

--- a/tests/integration/steps/components/steps.js
+++ b/tests/integration/steps/components/steps.js
@@ -1,7 +1,7 @@
 import yadda from '../../../helpers/yadda';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .then('I should see the text "$text"', function(text) {
       assert.equal(this.element.textContent.trim(), text);
     });

--- a/tests/integration/steps/steps.js
+++ b/tests/integration/steps/steps.js
@@ -1,13 +1,11 @@
 import yadda from '../../helpers/yadda';
-import { visit } from '@ember/test-helpers';
 
 export default function(assert) {
   return yadda.localisation.default.library()
-    .given('I type "Ember g feature make-feature"', async function() {
-      await visit('/');
+    .given('I type "Ember g feature make-feature"', function(){
       assert.ok(true, this.step);
     })
-    .when('I look in the folder', function() {
+    .when('I look in the folder', function(){
       assert.ok(true, this.step);
     });
 }

--- a/tests/unit/steps/context-steps.js
+++ b/tests/unit/steps/context-steps.js
@@ -1,7 +1,7 @@
 import yadda from '../../helpers/yadda';
 
 export default function(assert) {
-  return yadda.localisation.English.library()
+  return yadda.localisation.default.library()
     .when('I have no annotations', function() {
     })
     .then('the test context should have "$name"', function(property) {

--- a/tests/unit/steps/steps.js
+++ b/tests/unit/steps/steps.js
@@ -1,13 +1,11 @@
 import yadda from '../../helpers/yadda';
-import { visit } from '@ember/test-helpers';
 
 export default function(assert) {
   return yadda.localisation.default.library()
-    .given('I type "Ember g feature make-feature"', async function() {
-      await visit('/');
+    .given('I type "Ember g feature make-feature"', function(){
       assert.ok(true, this.step);
     })
-    .when('I look in the folder', function() {
+    .when('I look in the folder', function(){
       assert.ok(true, this.step);
     });
 }


### PR DESCRIPTION
This replaces #42, and is intended to be rolled into 0.4.0.

It allows options for Yadda to be passed through from `ember-cli-build.js`:  

```javascript
module.exports = function(defaults) {
  let app = new EmberApp(defaults, {

    'ember-cli-yadda': {
      yaddaOptions: { // passed through to yadda parseFeature()
        language: 'Polish', // converted to Yadda.localisation.Polish
        leftPlaceholderChar: '<',
        rightPlaceholderChar: '>'
      }

    }
  });
```
The language string is converted to a yadda localisation module in ember-cli-yadda's [feature parser](https://github.com/StateFarmIns/ember-cli-yadda/blob/644f302310a6c26d1e92c37456691d1c7d877293/lib/feature-parser.js#L16) b/c it was an easy place to insert it (yadda is available here).  It could probably go somewhere is if this doesn't seem right.

The location of the Yadda Configuration section in the readme file will need to be changed when #71 is merged, so this is currently WIP.