### PR TITLE
Send all arguments to scenario action

### DIFF
--- a/addon-test-support/mocha/test-runner.js
+++ b/addon-test-support/mocha/test-runner.js
@@ -36,7 +36,7 @@ export default function testFeature(feature, yadda, yaddaAnnotations, library) {
 function testScenario(scenario, feature, yadda, yaddaAnnotations, library) {
   let scenarioAction = yaddaAnnotations.runScenario(feature.annotations, scenario.annotations);
   if (typeof scenarioAction === 'function') {
-    scenarioAction.call(this, scenario);
+    scenarioAction.apply(this, arguments);
   } else {
     it(`Scenario: ${scenario.title}`, function() {
       let self = this;

--- a/addon-test-support/qunit/test-runner.js
+++ b/addon-test-support/qunit/test-runner.js
@@ -36,7 +36,7 @@ export default function testFeature(feature, yadda, yaddaAnnotations, library) {
 function testScenario(scenario, feature, yadda, yaddaAnnotations, library) {
   let scenarioAction = yaddaAnnotations.runScenario(feature.annotations, scenario.annotations);
   if (typeof scenarioAction === 'function') {
-    scenarioAction.apply(this, [].slice.call(arguments));
+    scenarioAction.apply(this, arguments);
   } else {
     test(`Scenario: ${scenario.title}`, function(assert) {
       let self = this;

--- a/addon-test-support/qunit/test-runner.js
+++ b/addon-test-support/qunit/test-runner.js
@@ -36,7 +36,7 @@ export default function testFeature(feature, yadda, yaddaAnnotations, library) {
 function testScenario(scenario, feature, yadda, yaddaAnnotations, library) {
   let scenarioAction = yaddaAnnotations.runScenario(feature.annotations, scenario.annotations);
   if (typeof scenarioAction === 'function') {
-    scenarioAction.call(this, scenario);
+    scenarioAction.apply(this, [].slice.call(arguments));
   } else {
     test(`Scenario: ${scenario.title}`, function(assert) {
       let self = this;


### PR DESCRIPTION
Doing this allows alternative scenario actions access to all the needed parameters to (for example) use qunit's "todo" function instead of "test" and keep the rest of the runner the same.
It also does not cause any conflicts as scenario is still sent to scenarioAction as the first argument.