### PR TITLE
Avoid importing yadda from ember-cli-yadda

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Because we probably have more features about bananas, we add the `Given I have b
 `/tests/acceptance/steps.js`
 
 ```js
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { visit } from '@ember/test-helpers';
 
 export default function(assert) {

--- a/blueprints/mocha/ember-cli-yadda/files/tests/acceptance/steps/steps.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/acceptance/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { expect } from 'chai';
 import { visit } from '@ember/test-helpers';
 

--- a/blueprints/mocha/ember-cli-yadda/files/tests/integration/steps/steps.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/integration/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { expect } from 'chai';
 
 export default function() {

--- a/blueprints/mocha/ember-cli-yadda/files/tests/unit/steps/steps.js
+++ b/blueprints/mocha/ember-cli-yadda/files/tests/unit/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { expect } from 'chai';
 
 export default function() {

--- a/blueprints/qunit/ember-cli-yadda/files/tests/acceptance/steps/steps.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/acceptance/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { visit } from '@ember/test-helpers';
 
 export default function(assert) {

--- a/blueprints/qunit/ember-cli-yadda/files/tests/integration/steps/steps.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/integration/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()

--- a/blueprints/qunit/ember-cli-yadda/files/tests/unit/steps/steps.js
+++ b/blueprints/qunit/ember-cli-yadda/files/tests/unit/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()

--- a/index.js
+++ b/index.js
@@ -44,24 +44,5 @@ module.exports = {
       options.persist = true;
     }
     this._options = options;
-  },
-  treeForAddonTestSupport(tree) {
-    // intentionally not calling _super here
-    // so that can have our `import`'s be
-    // import { yadda } from 'ember-cli-yadda';
-    // shamelessly stolen from https://github.com/cibernox/ember-native-dom-helpers/blob/19adea1683fc386baca6eb7c83cd0a147bd4d586/index.js
-    // and https://github.com/kaliber5/ember-window-mock/blob/master/index.js#L7-L24
-
-    const Funnel = require('broccoli-funnel');
-
-    let namespacedTree = new Funnel(tree, {
-      srcDir: '/',
-      destDir: `/${this.moduleName()}`,
-      annotation: `Addon#treeForTestSupport (${this.name})`,
-    });
-
-    return this.preprocessJs(namespacedTree, '/', this.name, {
-      registry: this.registry,
-    });
   }
 };

--- a/lib/feature-parser.js
+++ b/lib/feature-parser.js
@@ -38,10 +38,10 @@ class FeatureParser extends Filter {
     // import testRunner from 'ember-cli-yadda/test-support/${this.testFramework}/test-runner';
 
     let module = `
-      import { yadda } from 'ember-cli-yadda';
+      import yadda from 'yadda';
       import * as library from '${stepsPath}/${fileName}-steps';
       import yaddaAnnotations from '${basePath}/helpers/yadda-annotations';
-      import testRunner from 'ember-cli-yadda/${this.testFramework}/test-runner';
+      import testRunner from 'ember-cli-yadda/test-support/${this.testFramework}/test-runner';
 
       const feature = ${JSON.stringify(feature, null, 2)};
 

--- a/node-tests/fixtures/main/mocha/acceptance/steps/steps.js
+++ b/node-tests/fixtures/main/mocha/acceptance/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { expect } from 'chai';
 import { visit } from '@ember/test-helpers';
 

--- a/node-tests/fixtures/main/mocha/helpers/yadda.js
+++ b/node-tests/fixtures/main/mocha/helpers/yadda.js
@@ -1,2 +1,2 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 export default yadda;

--- a/node-tests/fixtures/main/mocha/integration/steps/steps.js
+++ b/node-tests/fixtures/main/mocha/integration/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { expect } from 'chai';
 
 export default function() {

--- a/node-tests/fixtures/main/mocha/unit/steps/steps.js
+++ b/node-tests/fixtures/main/mocha/unit/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { expect } from 'chai';
 
 export default function() {

--- a/node-tests/fixtures/main/qunit/acceptance/steps/steps.js
+++ b/node-tests/fixtures/main/qunit/acceptance/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { visit } from '@ember/test-helpers';
 
 export default function(assert) {

--- a/node-tests/fixtures/main/qunit/helpers/yadda.js
+++ b/node-tests/fixtures/main/qunit/helpers/yadda.js
@@ -1,2 +1,2 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 export default yadda;

--- a/node-tests/fixtures/main/qunit/integration/steps/steps.js
+++ b/node-tests/fixtures/main/qunit/integration/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()

--- a/node-tests/fixtures/main/qunit/unit/steps/steps.js
+++ b/node-tests/fixtures/main/qunit/unit/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()

--- a/tests/acceptance/steps/steps.js
+++ b/tests/acceptance/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 import { visit } from '@ember/test-helpers';
 
 export default function(assert) {

--- a/tests/helpers/yadda.js
+++ b/tests/helpers/yadda.js
@@ -1,2 +1,2 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 export default yadda;

--- a/tests/integration/steps/components/steps.js
+++ b/tests/integration/steps/components/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()

--- a/tests/integration/steps/steps.js
+++ b/tests/integration/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()

--- a/tests/unit/steps/context-steps.js
+++ b/tests/unit/steps/context-steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()

--- a/tests/unit/steps/steps.js
+++ b/tests/unit/steps/steps.js
@@ -1,4 +1,4 @@
-import { yadda } from 'ember-cli-yadda';
+import yadda from 'yadda';
 
 export default function(assert) {
   return yadda.localisation.default.library()


### PR DESCRIPTION
Instead rely on `ember-auto-import` to import it directly from `yadda`. This way wo do not need users to import anything directly from `ember-cli-yadda`, avoiding the `treeForAddonTestSupport` hook trickery that causes issues with `ember-auto-import`.

Fixes #82